### PR TITLE
Patch CVEs

### DIFF
--- a/Configuration.UnitTests/ConsulRx.Configuration.UnitTests.csproj
+++ b/Configuration.UnitTests/ConsulRx.Configuration.UnitTests.csproj
@@ -4,14 +4,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Configuration\ConsulRx.Configuration.csproj" />

--- a/Configuration/ConsulRx.Configuration.csproj
+++ b/Configuration/ConsulRx.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Description>Provides a configuration source that pulls values from Consul's Service Catalog and KV 
     Store.</Description>
     <Copyright>2017-2020</Copyright>

--- a/ConsulRx.UnitTests/ConsulRx.UnitTests.csproj
+++ b/ConsulRx.UnitTests/ConsulRx.UnitTests.csproj
@@ -7,9 +7,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Moq" Version="4.18.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ConsulRx/ConsulRx.csproj
+++ b/ConsulRx/ConsulRx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
-    <Version>1.0.2</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.1.0</Version>
     <Description>A library for consuming consul values in a continuous stream using the Reactive 
     Extensions</Description>
     <Copyright>2017-2018</Copyright>
@@ -16,9 +16,9 @@
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Consul" Version="0.7.2.*" />
-    <PackageReference Include="Spiffy.Monitoring" Version="4.0.*" />
-    <PackageReference Include="System.Reactive" Version="3.1.*" />
+    <PackageReference Include="Consul" Version="1.6.10.7" />
+    <PackageReference Include="Spiffy.Monitoring" Version="6.0.3" />
+    <PackageReference Include="System.Reactive" Version="4.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.*" />
   </ItemGroup>
 </Project>

--- a/Templating.CommandLine/ConsulRx.Templating.CommandLine.csproj
+++ b/Templating.CommandLine/ConsulRx.Templating.CommandLine.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.2" />
-    <PackageReference Include="NetEscapades.Configuration.Yaml" Version="1.3.1" />
+    <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="*.yml" CopyToOutputDirectory="Always" />

--- a/Templating.UnitTests/ConsulRx.Templating.UnitTests.csproj
+++ b/Templating.UnitTests/ConsulRx.Templating.UnitTests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Moq" Version="4.18.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Templating/ConsulRx.Templating.csproj
+++ b/Templating/ConsulRx.Templating.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>ConsulRx.Templating</PackageId>
-    <Version>0.1.0-alpha</Version>
+    <Version>0.2.0-alpha</Version>
     <Authors>Andy Alm</Authors>
     <Description>.NET API for executing templates that plug into Consul values and automatically update when consul values change.</Description>
   </PropertyGroup>
@@ -11,9 +11,9 @@
     <ProjectReference Include="..\ConsulRx\ConsulRx.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="1.1.*" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="Spiffy.Monitoring" Version="4.0.*" />
+    <PackageReference Include="Spiffy.Monitoring" Version="6.0.3" />
   </ItemGroup>
 </Project>

--- a/TestSupport/ConsulRx.TestSupport.csproj
+++ b/TestSupport/ConsulRx.TestSupport.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ConsulRx\ConsulRx.csproj" />

--- a/TestSupport/FakeConsulClient.cs
+++ b/TestSupport/FakeConsulClient.cs
@@ -352,6 +352,9 @@ namespace ConsulRx.TestSupport
         }
 
         public IACLEndpoint ACL { get; }
+        public IPolicyEndpoint Policy { get; }
+        public IRoleEndpoint Role { get; }
+        public ITokenEndpoint Token { get; }
         public IAgentEndpoint Agent { get; }
         public ICatalogEndpoint Catalog => this;
         public IEventEndpoint Event { get; }


### PR DESCRIPTION
Redo of https://github.com/andyalm/consul-rx/pull/7 with a narrower scope; focusing on specific CVEs only

## Version Changes
### `ConsulRx`
```diff
-1.0.2
+1.1.0
```
### `ConsulRx.Configuration`
```diff
-1.1.0
+1.2.0
```
### `ConsulRx.Templating`
```diff
-0.1.0-alpha
+0.2.0-alpha
```

```text
Package                        Version CVE
-------                        ------- ---
Newtonsoft.Json                10.0.2  https://github.com/advisories/GHSA-5crp-9r3c-p9vr
System.Net.Http                4.3.0   https://github.com/advisories/GHSA-7jgj-8wvc-jh57
System.Net.Http.WinHttpHandler 4.0.0   https://github.com/advisories/GHSA-6xh7-4v2w-36q6
System.Net.Http.WinHttpHandler 4.0.0   https://github.com/advisories/GHSA-ch6p-4jcm-h8vh
System.Net.Http.WinHttpHandler 4.0.0   https://github.com/advisories/GHSA-j8f4-2w4p-mhjc
System.Net.Http.WinHttpHandler 4.0.0   https://github.com/advisories/GHSA-qhqf-ghgh-x2m4
System.Text.RegularExpressions 4.3.0   https://github.com/advisories/GHSA-cmhx-cq75-c4mj
YamlDotNet                     4.2.1   https://github.com/advisories/GHSA-rpch-cqj9-h65r
```

Also:
https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/netstandard-warning

## Details

### **Newtonsoft**
* Consul 1.6.10.7 updated to pick up Newtonsoft.Json 13.0.1 (8/1/2022)

### **System.Net.Http**
* Spiffy.Monitoring (10/30/2020)
* System.Reactive (8/13/2018)
* Microsoft.AspNetCore.Razor (8/11/2017)
* Moq (5/11/2022)
* NSubstitute (7/10/2022)
* xunit (2/16/2024)

### **System.Net.Http.WinHttpHandler**
* went away by updating the `System.Net.Http` vulnerabilities

## **System.Text.RegularExpressions**
* Microsoft.CodeAnalysis.CSharp (4/2/2019)

## **YamlDotNet**
* NetEscapades.Configuration.Yaml (4/27/2023)

## Other Notes
`ConsulRx.Templating` still has some issues, but there are no suitable upgrade paths (`Microsoft.Extensions.CommandLineUtils` deprecated, breaking changes in `Microsoft.AspNetCore.Razor`)