### PR TITLE
Honor CONSUL_HTTP_ADDR environment variable

### DIFF
--- a/Configuration.TestHarness/Program.cs
+++ b/Configuration.TestHarness/Program.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using ConsulRx.Configuration;
+﻿using ConsulRx.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddConsul(consul =>
 {
-    var consulAddr = Environment.GetEnvironmentVariable("CONSUL_HTTP_ADDR");
-    if (!string.IsNullOrEmpty(consulAddr))
-        consul.Endpoint($"http://{consulAddr}");
     consul
         .AutoUpdate()
         .MapHttpService("service1-http", "serviceEndpoints:service1")

--- a/ConsulRx/ObservableConsul.cs
+++ b/ConsulRx/ObservableConsul.cs
@@ -33,7 +33,7 @@ namespace ConsulRx
 
             _configuration = config;
 
-            var address = new Uri(config.Endpoint ?? "http://localhost:8500");
+            var address = new Uri(config.Endpoint);
             _client = new ConsulHttpClient(address, config.Datacenter);
         }
 

--- a/ConsulRx/ObservableConsulConfiguration.cs
+++ b/ConsulRx/ObservableConsulConfiguration.cs
@@ -10,12 +10,21 @@ namespace ConsulRx
         {
             get
             {
-                if (!string.IsNullOrEmpty(_endpoint))
-                    return _endpoint;
+                var endpoint = _endpoint
+                    ?? Environment.GetEnvironmentVariable("CONSUL_HTTP_ADDR")
+                    ?? "localhost:8500";
 
-                return null;
+                return NormalizeEndpoint(endpoint);
             }
             set => _endpoint = value;
+        }
+
+        private static string NormalizeEndpoint(string endpoint)
+        {
+            if (Uri.TryCreate(endpoint, UriKind.Absolute, out _))
+                return endpoint;
+
+            return $"http://{endpoint}";
         }
         public string Datacenter { get; set; }
         public string AclToken { get; set; }


### PR DESCRIPTION
  Honor `CONSUL_HTTP_ADDR` environment variable

  ## Problem

  PR #9 replaced the `Consul` NuGet package with a lightweight `HttpClient` implementation. The old package automatically read the [`CONSUL_HTTP_ADDR` environment variable](https://github.com/G-Research/consuldotnet/blob/master/Consul/Client.cs#L164) to determine the Consul endpoint. That
  behavior was missed.  As a result, consumers relying on `CONSUL_HTTP_ADDR` fell back to `localhost:8500` (and most likely failed with connection refused)

  ## Approach

  Moved all endpoint resolution into `ObservableConsulConfiguration.Endpoint`:

  1. Explicit endpoint (set via property) takes priority
  2. Falls back to `CONSUL_HTTP_ADDR` environment variable
  3. Falls back to `localhost:8500`

  All values pass through `NormalizeEndpoint()` which prepends `http://` when no scheme is present — matching the Consul convention where `CONSUL_HTTP_ADDR` is typically a bare `host:port`.

  Removed the `?? "http://localhost:8500"` fallback from `ObservableConsul`'s constructor since the property now always returns a resolved value. Removed the manual env var workaround from the test harness since the library handles it natively.