### PR TITLE
Default auto-update to enabled for 2.x

### DIFF
--- a/Configuration.UnitTests/ConfigurationLoadingSpec.cs
+++ b/Configuration.UnitTests/ConfigurationLoadingSpec.cs
@@ -61,8 +61,10 @@ namespace ConsulRx.Configuration.UnitTests
             consul.GetDependenciesAsync(null)
                 .ThrowsForAnyArgs(
                     new ConsulErrorException(new QueryResult {StatusCode = HttpStatusCode.InternalServerError}));
-            
-            var configProvider = (ConsulConfigurationProvider) _configSource.Build(consul);
+
+            var configProvider = (ConsulConfigurationProvider) _configSource
+                .Configure(options => options.AutoUpdate = false)
+                .Build(consul);
             await configProvider.LoadAsync();
             
             configProvider.TryGet("consul:folder1:item1", out var value).Should().BeTrue();
@@ -104,7 +106,9 @@ namespace ConsulRx.Configuration.UnitTests
             consul.GetDependenciesAsync(null)
                 .ReturnsForAnyArgs(
                     new ConsulState().UpdateKVNode(new KeyValueNode("apps/myapp/folder1/item1", "value1")));
-            var configProvider = (ConsulConfigurationProvider) _configSource.Build(consul);
+            var configProvider = (ConsulConfigurationProvider) _configSource
+                .Configure(options => options.AutoUpdate = false)
+                .Build(consul);
             await configProvider.LoadAsync();
 
             consul.DidNotReceiveWithAnyArgs().ObserveDependencies(null);

--- a/Configuration/ConsulConfigurationSource.cs
+++ b/Configuration/ConsulConfigurationSource.cs
@@ -12,16 +12,29 @@ namespace ConsulRx.Configuration
         private readonly KVTreeConfigMappingCollection _kvTreeConfigMappings = new KVTreeConfigMappingCollection();
         private readonly KVItemConfigMappingCollection _kvItemConfigMappings = new KVItemConfigMappingCollection();
         private IEmergencyCache _cache = NullEmergencyCache.Instance;
-        private bool _autoUpdate = false;
+        private readonly ConsulRxOptions _options = new ConsulRxOptions();
+        private bool _autoUpdateOptionsApplied = false;
 
         public ConsulConfigurationSource()
         {
             var autoUpdateEnv = Environment.GetEnvironmentVariable("CONSULRX_AUTO_UPDATE");
-            if(autoUpdateEnv != null &&
-               (autoUpdateEnv.Equals("1") || autoUpdateEnv.Equals("true", StringComparison.OrdinalIgnoreCase)))
+            if (autoUpdateEnv != null && IsFalsey(autoUpdateEnv))
             {
-                AutoUpdate();
+                _options.AutoUpdate = false;
             }
+        }
+
+        public ConsulConfigurationSource Configure(Action<ConsulRxOptions> configureOptions)
+        {
+            configureOptions(_options);
+            return this;
+        }
+
+        private static bool IsFalsey(string value)
+        {
+            return value.Length == 0
+                || value.Equals("0")
+                || value.Equals("false", StringComparison.OrdinalIgnoreCase);
         }
         
         public ConsulConfigurationSource Endpoint(string consulEndpoint)
@@ -107,9 +120,10 @@ namespace ConsulRx.Configuration
         /// </returns>
         public ConsulConfigurationSource AutoUpdate(AutoUpdateOptions options = null)
         {
-            _autoUpdate = true;
+            _options.AutoUpdate = true;
             options = options ?? new AutoUpdateOptions();
-            
+            _autoUpdateOptionsApplied = true;
+
             _consulConfig.RetryDelay = options.ErrorRetryInterval;
             _consulConfig.LongPollMaxWait = options.UpdateMaxInterval;
 
@@ -125,7 +139,14 @@ namespace ConsulRx.Configuration
 
         internal IConfigurationProvider Build(IObservableConsul consulClient)
         {
-            return new ConsulConfigurationProvider(consulClient, _cache, _consulDependencies, _serviceConfigMappings, _kvTreeConfigMappings, _kvItemConfigMappings, _autoUpdate);
+            if (_options.AutoUpdate && !_autoUpdateOptionsApplied)
+            {
+                var defaults = new AutoUpdateOptions();
+                _consulConfig.RetryDelay = defaults.ErrorRetryInterval;
+                _consulConfig.LongPollMaxWait = defaults.UpdateMaxInterval;
+            }
+
+            return new ConsulConfigurationProvider(consulClient, _cache, _consulDependencies, _serviceConfigMappings, _kvTreeConfigMappings, _kvItemConfigMappings, _options.AutoUpdate);
         }
 
         public ConsulConfigurationSource UseFilesystemCache()

--- a/Configuration/ConsulRxOptions.cs
+++ b/Configuration/ConsulRxOptions.cs
@@ -1,0 +1,7 @@
+namespace ConsulRx.Configuration
+{
+    public class ConsulRxOptions
+    {
+        public bool AutoUpdate { get; set; } = true;
+    }
+}


### PR DESCRIPTION
 Default auto-update to enabled for 2.x

  ## Problem

  Auto-update is the right default for most ConsulRx consumers, but it
  currently requires explicit opt-in via `.AutoUpdate()` or the
  `CONSULRX_AUTO_UPDATE` environment variable. This means every new
  integration has to remember to enable it, and forgetting silently
  degrades to stale configuration.

  ## Approach

  Flip auto-update to opt-out as a 2.x breaking change:

  - `ConsulRxOptions.AutoUpdate` defaults to `true`
  - `CONSULRX_AUTO_UPDATE` env var now **disables** when set to a falsey
    value (`""`, `"0"`, `"false"`); unset means enabled
  - New `Configure(Action<ConsulRxOptions>)` fluent method for code-based
    opt-out without needing the env var
  - `Build()` applies default auto-update timing automatically when
    `AutoUpdate()` was never called explicitly

  Existing callers that already call `.AutoUpdate()` are unaffected. Callers
  that relied on auto-update being off by default will need to explicitly
  disable it — this is the intentional breaking change for 2.x.

  ## Testing

  All 51 existing tests pass. Tests that verify "auto-update disabled"
  behavior now explicitly opt out via `.Configure(options => options.AutoUpdate = false)`.